### PR TITLE
Feature/add support custom text messages

### DIFF
--- a/library/src/main/java/ch/tutti/android/applover/AppLover.java
+++ b/library/src/main/java/ch/tutti/android/applover/AppLover.java
@@ -20,6 +20,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Build;
+import android.support.annotation.NonNull;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -68,7 +69,7 @@ public class AppLover {
 
     private String mFeedbackEmail;
 
-    private AppLoverDialogStyle mStyle;
+    private AppLoverDialogsProperties mDialogsProperties;
 
     private HashMap<String, Integer> mCustomEventThresholdMap
             = new HashMap<String, Integer>();
@@ -100,12 +101,13 @@ public class AppLover {
         return this;
     }
 
-    public AppLoverDialogStyle getStyle() {
-        return mStyle == null ? new AppLoverDialogStyle() : mStyle;
+    @NonNull
+    public AppLoverDialogsProperties getProperties() {
+        return mDialogsProperties == null ? new AppLoverDialogsProperties() : mDialogsProperties;
     }
 
-    public AppLover setStyle(AppLoverDialogStyle style) {
-        mStyle = style;
+    public AppLover setProperties(AppLoverDialogsProperties properties) {
+        mDialogsProperties = properties;
         return this;
     }
 

--- a/library/src/main/java/ch/tutti/android/applover/AppLoverDialogFactory.java
+++ b/library/src/main/java/ch/tutti/android/applover/AppLoverDialogFactory.java
@@ -56,7 +56,7 @@ class AppLoverDialogFactory {
             final int appNameResId) {
         final Context context = listener.getActivity();
         final AlertDialog.Builder builder =
-                createBuilder(context, AppLover.get(context).getStyle().loveDialogStyle);
+                createBuilder(context, AppLover.get(context).getProperties().loveDialogStyle);
         builder.setMessage(Phrase.from(context, R.string.applover_do_you_like_this_app)
                 .putOptional("app_name", context.getString(appNameResId))
                 .format());
@@ -81,7 +81,7 @@ class AppLoverDialogFactory {
 
     private static Dialog createRateDialog(final Context context, final int appNameResId) {
         final AlertDialog.Builder builder =
-                createBuilder(context, AppLover.get(context).getStyle().rateDialogStyle);
+                createBuilder(context, AppLover.get(context).getProperties().rateDialogStyle);
         builder.setMessage(Phrase.from(context, R.string.applover_rate_text)
                 .putOptional("app_name", context.getString(appNameResId))
                 .format());
@@ -121,8 +121,10 @@ class AppLoverDialogFactory {
     }
 
     private static Dialog createEmailDialog(final Context context, final int appNameResId) {
-        final AlertDialog.Builder builder =
-                createBuilder(context, AppLover.get(context).getStyle().emailDialogStyle);
+        AppLoverDialogsProperties.Style style = AppLover.get(context).getProperties().emailDialogStyle;
+        
+        final AlertDialog.Builder builder = createBuilder(context, style);
+        
         builder.setMessage(Phrase.from(context, R.string.applover_feedback_text)
                 .putOptional("app_name", context.getString(appNameResId))
                 .format());
@@ -169,7 +171,7 @@ class AppLoverDialogFactory {
     }
 
     private static AlertDialog.Builder createBuilder(Context context,
-            AppLoverDialogStyle.Style style) {
+            AppLoverDialogsProperties.Style style) {
         if (style != null && style.theme != 0) {
             return new AlertDialog.Builder(new ContextThemeWrapper(context, style.theme));
         } else {

--- a/library/src/main/java/ch/tutti/android/applover/AppLoverDialogFactory.java
+++ b/library/src/main/java/ch/tutti/android/applover/AppLoverDialogFactory.java
@@ -55,12 +55,13 @@ class AppLoverDialogFactory {
     private static Dialog createFirstDialog(final AppLoverDialogHelper.DialogListener listener,
             final int appNameResId) {
         final Context context = listener.getActivity();
-        final AlertDialog.Builder builder =
-                createBuilder(context, AppLover.get(context).getProperties().loveDialogStyle);
-        builder.setMessage(Phrase.from(context, R.string.applover_do_you_like_this_app)
+        AppLoverDialogsProperties.Style style = AppLover.get(context).getProperties().loveDialogStyle;
+
+        final AlertDialog.Builder builder = createBuilder(context, style);
+        builder.setMessage(Phrase.from(context, style.getMessage(R.string.applover_do_you_like_this_app))
                 .putOptional("app_name", context.getString(appNameResId))
                 .format());
-        builder.setPositiveButton(R.string.applover_yes, new DialogInterface.OnClickListener() {
+        builder.setPositiveButton(style.getPositiveButtonText(R.string.applover_yes), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 AppLover.get(null)
@@ -68,7 +69,7 @@ class AppLoverDialogFactory {
                 listener.showRateDialog();
             }
         });
-        builder.setNegativeButton(R.string.applover_no, new DialogInterface.OnClickListener() {
+        builder.setNegativeButton(style.getNegativeButtonText(R.string.applover_no), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 AppLover.get(null)
@@ -80,12 +81,12 @@ class AppLoverDialogFactory {
     }
 
     private static Dialog createRateDialog(final Context context, final int appNameResId) {
-        final AlertDialog.Builder builder =
-                createBuilder(context, AppLover.get(context).getProperties().rateDialogStyle);
-        builder.setMessage(Phrase.from(context, R.string.applover_rate_text)
+        AppLoverDialogsProperties.Style style = AppLover.get(context).getProperties().rateDialogStyle;
+        final AlertDialog.Builder builder = createBuilder(context, style);
+        builder.setMessage(Phrase.from(context, style.getMessage(R.string.applover_rate_text))
                 .putOptional("app_name", context.getString(appNameResId))
                 .format());
-        builder.setPositiveButton(R.string.applover_rate_now,
+        builder.setPositiveButton(style.getPositiveButtonText(R.string.applover_rate_now),
                 new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
@@ -99,15 +100,16 @@ class AppLoverDialogFactory {
                     }
                 }
         );
-        builder.setNeutralButton(R.string.applover_later, new DialogInterface.OnClickListener() {
-            @Override
-            public void onClick(DialogInterface dialog, int which) {
-                AppLover.get(null).trackDialogButtonPressed(
-                        AppLover.DIALOG_TYPE_RATE, AppLover.BUTTON_LATER);
-                AppLover.get(context).reset(context);
-            }
-        });
-        builder.setNegativeButton(R.string.applover_no_thanks,
+        builder.setNeutralButton(style.getNeutralButtonText(R.string.applover_later),
+                new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        AppLover.get(null).trackDialogButtonPressed(
+                                AppLover.DIALOG_TYPE_RATE, AppLover.BUTTON_LATER);
+                        AppLover.get(context).reset(context);
+                    }
+                });
+        builder.setNegativeButton(style.getNegativeButtonText(R.string.applover_no_thanks),
                 new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
@@ -125,10 +127,10 @@ class AppLoverDialogFactory {
         
         final AlertDialog.Builder builder = createBuilder(context, style);
         
-        builder.setMessage(Phrase.from(context, R.string.applover_feedback_text)
+        builder.setMessage(Phrase.from(context, style.getMessage(R.string.applover_feedback_text))
                 .putOptional("app_name", context.getString(appNameResId))
                 .format());
-        builder.setPositiveButton(R.string.applover_feedback_now,
+        builder.setPositiveButton(style.getPositiveButtonText(R.string.applover_feedback_now),
                 new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
@@ -149,7 +151,7 @@ class AppLoverDialogFactory {
                     }
                 }
         );
-        builder.setNeutralButton(R.string.applover_later, new DialogInterface.OnClickListener() {
+        builder.setNeutralButton(style.getNeutralButtonText(R.string.applover_later), new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 AppLover.get(null).trackDialogButtonPressed(
@@ -157,7 +159,7 @@ class AppLoverDialogFactory {
                 AppLover.get(context).reset(context);
             }
         });
-        builder.setNegativeButton(R.string.applover_no_thanks,
+        builder.setNegativeButton(style.getNegativeButtonText(R.string.applover_no_thanks),
                 new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {

--- a/library/src/main/java/ch/tutti/android/applover/AppLoverDialogHelper.java
+++ b/library/src/main/java/ch/tutti/android/applover/AppLoverDialogHelper.java
@@ -102,7 +102,7 @@ class AppLoverDialogHelper {
     public static void updateDialogStyle(Bundle arguments, Dialog dialog) {
         AlertDialog alertDialog = (AlertDialog) dialog;
         int dialogType = arguments.getInt(ARGUMENT_DIALOG_TYPE);
-        AppLoverDialogStyle style = AppLover.get(null).getStyle();
+        AppLoverDialogsProperties style = AppLover.get(null).getProperties();
 
         switch (dialogType) {
             case AppLover.DIALOG_TYPE_FIRST:
@@ -117,7 +117,7 @@ class AppLoverDialogHelper {
         }
     }
 
-    private static void applyStyle(AlertDialog dialog, AppLoverDialogStyle.Style style) {
+    private static void applyStyle(AlertDialog dialog, AppLoverDialogsProperties.Style style) {
         if (style == null) {
             return;
         }

--- a/library/src/main/java/ch/tutti/android/applover/AppLoverDialogsProperties.java
+++ b/library/src/main/java/ch/tutti/android/applover/AppLoverDialogsProperties.java
@@ -15,7 +15,7 @@
  */
 package ch.tutti.android.applover;
 
-public class AppLoverDialogStyle {
+public class AppLoverDialogsProperties {
 
     public Style loveDialogStyle;
 
@@ -23,17 +23,17 @@ public class AppLoverDialogStyle {
 
     public Style emailDialogStyle;
 
-    public AppLoverDialogStyle loveStyle(Style style) {
+    public AppLoverDialogsProperties loveStyle(Style style) {
         loveDialogStyle = style;
         return this;
     }
 
-    public AppLoverDialogStyle rateStyle(Style style) {
+    public AppLoverDialogsProperties rateStyle(Style style) {
         rateDialogStyle = style;
         return this;
     }
 
-    public AppLoverDialogStyle emailStyle(Style style) {
+    public AppLoverDialogsProperties emailStyle(Style style) {
         emailDialogStyle = style;
         return this;
     }
@@ -41,12 +41,16 @@ public class AppLoverDialogStyle {
     public static class Style {
 
         int theme;
-
+        
         int positiveButtonBackground;
-
+        
         int neutralButtonBackground;
-
+        
         int negativeButtonBackground;
+        
+        // string resources ids for text customization
+        int message, positiveButtonText, negativeButtonText, neutralButtonText;
+        
 
         public Style theme(int theme) {
             this.theme = theme;
@@ -65,6 +69,28 @@ public class AppLoverDialogStyle {
 
         public Style negativeBackground(int background) {
             negativeButtonBackground = background;
+            return this;
+        }
+
+        public Style message(int stringId) {
+            message = stringId;
+            return this;
+        }
+        
+        public Style positiveButtonText(int stringId) {
+            positiveButtonText = stringId;
+            return this;
+        }
+
+
+        public Style negativeButtonText(int stringId) {
+            negativeButtonText = stringId;
+            return this;
+        }
+
+
+        public Style neutralButtonText(int stringId) {
+            neutralButtonText = stringId;
             return this;
         }
     }

--- a/library/src/main/java/ch/tutti/android/applover/AppLoverDialogsProperties.java
+++ b/library/src/main/java/ch/tutti/android/applover/AppLoverDialogsProperties.java
@@ -15,13 +15,18 @@
  */
 package ch.tutti.android.applover;
 
+import android.support.annotation.NonNull;
+
 public class AppLoverDialogsProperties {
 
-    public Style loveDialogStyle;
+    @NonNull
+    public Style loveDialogStyle = new AppLoverDialogsProperties.Style();
 
-    public Style rateDialogStyle;
+    @NonNull
+    public Style rateDialogStyle = new AppLoverDialogsProperties.Style();
 
-    public Style emailDialogStyle;
+    @NonNull
+    public Style emailDialogStyle = new AppLoverDialogsProperties.Style();
 
     public AppLoverDialogsProperties loveStyle(Style style) {
         loveDialogStyle = style;
@@ -49,8 +54,7 @@ public class AppLoverDialogsProperties {
         int negativeButtonBackground;
         
         // string resources ids for text customization
-        int message, positiveButtonText, negativeButtonText, neutralButtonText;
-        
+        private int message, positiveButtonText, negativeButtonText, neutralButtonText;
 
         public Style theme(int theme) {
             this.theme = theme;
@@ -92,6 +96,34 @@ public class AppLoverDialogsProperties {
         public Style neutralButtonText(int stringId) {
             neutralButtonText = stringId;
             return this;
+        }
+
+        /**
+         * get the string id if previously set, default value otherwise
+         */
+        int getMessage(int defaultValue) {
+           return message > 0 ? message : defaultValue;
+        }
+
+        /**
+         * get the string id if previously set, default value otherwise
+         */
+        int getPositiveButtonText(int defaultValue) {
+            return positiveButtonText > 0 ? positiveButtonText : defaultValue;
+        }
+
+        /**
+         * get the string id if previously set, default value otherwise
+         */
+        int getNegativeButtonText(int defaultValue) {
+            return negativeButtonText > 0 ? negativeButtonText : defaultValue;
+        }
+
+        /**
+         * get the string id if previously set, default value otherwise
+         */
+        int getNeutralButtonText(int defaultValue) {
+            return neutralButtonText > 0 ? neutralButtonText : defaultValue;
         }
     }
 }

--- a/sample/src/main/java/ch/tutti/android/applover/sample/MainActivity.java
+++ b/sample/src/main/java/ch/tutti/android/applover/sample/MainActivity.java
@@ -24,7 +24,7 @@ import android.widget.TextView;
 import java.security.InvalidParameterException;
 
 import ch.tutti.android.applover.AppLover;
-import ch.tutti.android.applover.AppLoverDialogStyle;
+import ch.tutti.android.applover.AppLoverDialogsProperties;
 import ch.tutti.android.applover.criteria.AppLoverAppLaunchCriteria;
 import ch.tutti.android.applover.criteria.AppLoverCriteriaBuilder;
 import ch.tutti.android.applover.criteria.AppLoverCustomEventCriteria;
@@ -48,13 +48,17 @@ public class MainActivity extends ActionBarActivity implements View.OnClickListe
         // Basic configuration. Email is needed. Tracking (analytics) and style are optional.
         appLover.setFeedbackEmail("support@yourapp.com")
                 .setOnTrackListener(new SampleOnTrackListener())
-                .setStyle(new AppLoverDialogStyle()
-                        .loveStyle(new AppLoverDialogStyle.Style()
+                .setProperties(new AppLoverDialogsProperties()
+                        .loveStyle(new AppLoverDialogsProperties.Style()
                                 .positiveBackground(R.drawable.button_positive)
-                                .negativeBackground(R.drawable.button_negative))
-                        .rateStyle(new AppLoverDialogStyle.Style()
+                                .negativeBackground(R.drawable.button_negative)
+                                .message(R.string.custom_like_message)
+                                .positiveButtonText(R.string.yes_button)
+                                .negativeButtonText(R.string.no_button)
+                                .neutralButtonText(R.string.may_be_button))
+                        .rateStyle(new AppLoverDialogsProperties.Style()
                                 .positiveBackground(R.drawable.button_positive))
-                        .emailStyle(new AppLoverDialogStyle.Style()
+                        .emailStyle(new AppLoverDialogsProperties.Style()
                                 .positiveBackground(R.drawable.button_positive)));
 
         // Setting up of thresholds
@@ -83,7 +87,7 @@ public class MainActivity extends ActionBarActivity implements View.OnClickListe
                         ).build()
                 ).build()
         );
-
+        
         // Monitor launch
         appLover.monitorLaunch(this);
 

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -2,5 +2,9 @@
 <resources>
 
     <string name="app_name">App Lover sample</string>
+    <string name="yes_button">But why?</string>
+    <string name="no_button">no, screw it</string>
+    <string name="may_be_button">may be later...</string>
+    <string name="custom_like_message">do you like our badas app</string>
 
 </resources>


### PR DESCRIPTION
Small extension to dialog styling to allow custom dialog/button texts.

Main changes : 
`AppLoverDialogStyle` -> (renamedTo) `AppLoverDialogsProperties`
These methods were added to `AppLoverDialogsProperties.Style` :
- message
- positiveButtonText
- negativeButtonText
- neutralButtonText
